### PR TITLE
Support zstd compression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Operating System :: OS Independent",
 ]
-dependencies = ["zenlib >= 3.0.2"]
+dependencies = ["zenlib >= 3.0.2", "zstd >= 1.5.6.1"]
 
 [project.scripts]
 pycpio = "pycpio.main:main"

--- a/src/pycpio/writer/writer.py
+++ b/src/pycpio/writer/writer.py
@@ -55,6 +55,11 @@ class CPIOWriter:
 
             self.logger.info("XZ compressing the CPIO data, original size: %.2f MiB" % (len(data) / (2**20)))
             data = lzma.compress(data, check=self.xz_crc)
+        elif self.compression == "zstd":
+            import zstd
+
+            self.logger.info("ZSTD compressing the CPIO data, original size: %.2f MiB" % (len(data) / (2**20)))
+            data = zstd.compress(data, 10)
         elif self.compression is not False:
             raise NotImplementedError("Compression type not supported: %s" % self.compression)
         return data


### PR DESCRIPTION
I hardcoded compression level 10. On my system it compresses the initramfs I generated under a second.

Numbers from my testing:
* ugrd.cpio is 20MB
* ugrd.cpio.xz is 6.2MB
  * Compression takes 14s
  * Decompression takes 0.5s
* ugrd.cpio.zst is 7.5MB
  * Compress takes 0.88s
  * Decompression takes 0.08s